### PR TITLE
Use a more portable shebang

### DIFF
--- a/dfu.py
+++ b/dfu.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import tealblue
 import sys

--- a/pynus.py
+++ b/pynus.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import tealblue
 import termios

--- a/tealblue.py
+++ b/tealblue.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import dbus
 import dbus.service


### PR DESCRIPTION
Some systems (NixOS, virtualenvs...) do not put python3 in /usr/bin.